### PR TITLE
Specify node version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,5 +34,8 @@
   "bugs": {
     "url": "https://github.com/MARKETProtocol/MARKETProtocol/issues"
   },
-  "homepage": "https://github.com/MARKETProtocol/MARKETProtocol#readme"
+  "homepage": "https://github.com/MARKETProtocol/MARKETProtocol#readme",
+  "engines": {
+    "node": ">=8.10.0"
+  }
 }


### PR DESCRIPTION
Related issue #56 

**Problem**

Users with older Node (<8.x) will not be able to run the code as some parts of the codebase is using `async` keyword.

**Solution**

Define inside `package.json` min. version of Node to be used to run the code.