### PR TITLE
Feature/29 bring test coverage for market contract

### DIFF
--- a/test/GasOraclize.js
+++ b/test/GasOraclize.js
@@ -87,7 +87,7 @@ contract('MarketContractOraclize.CallBackExpiration', function(accounts) {
         setTimeout(check, 1000)
     });
 
-    await waitForContractSettledEvent(30000);
+    await waitForContractSettledEvent(60000);
     assert.notEqual(txReceipt, null, "Oraclize callback did not arrive. Please increase QUERY_CALLBACK_GAS!");
 
     })


### PR DESCRIPTION
This PR solves both #29 and #30.

New tests:

* Should fail to deploy a contract with priceFloor equal to priceCap
 * Should fail to deploy a contract with expiration in the past
 * Request early settlement after contract settled
 * Should fail to deploy a contract with expiration set after 60 days
 * Should fail for attempt to call Oraclize callback
 * Should fail for attempt to self-trade
 * Should fail for attempt to cancel twice full qty
