### PR TITLE
Feature/upgrade compiler to 0 4 24

### DIFF
--- a/contracts/Creatable.sol
+++ b/contracts/Creatable.sol
@@ -14,7 +14,7 @@
     limitations under the License.
 */
 
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 
 // Contract creators may be rewarded in the future with bounties or other special privileges.  Additionally

--- a/contracts/Linkable.sol
+++ b/contracts/Linkable.sol
@@ -14,7 +14,7 @@
     limitations under the License.
 */
 
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 
 /// @title Linkable

--- a/contracts/MarketCollateralPool.sol
+++ b/contracts/MarketCollateralPool.sol
@@ -14,7 +14,7 @@
     limitations under the License.
 */
 
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 import "./libraries/MathLib.sol";
 import "./tokens/MarketToken.sol";

--- a/contracts/MarketContract.sol
+++ b/contracts/MarketContract.sol
@@ -14,7 +14,7 @@
     limitations under the License.
 */
 
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 import "./Creatable.sol";
 import "./MarketCollateralPool.sol";

--- a/contracts/MarketContractRegistry.sol
+++ b/contracts/MarketContractRegistry.sol
@@ -14,7 +14,7 @@
     limitations under the License.
 */
 
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
 import "./MarketContractRegistryInterface.sol";

--- a/contracts/MarketContractRegistryInterface.sol
+++ b/contracts/MarketContractRegistryInterface.sol
@@ -14,7 +14,7 @@
     limitations under the License.
 */
 
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 contract MarketContractRegistryInterface {
     function addAddressToWhiteList(address contractAddress) external;

--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 contract Migrations {
   address public owner;

--- a/contracts/libraries/MathLib.sol
+++ b/contracts/libraries/MathLib.sol
@@ -13,7 +13,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 */
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 
 /// @title Math function library with overflow protection inspired by Open Zeppelin

--- a/contracts/libraries/OrderLib.sol
+++ b/contracts/libraries/OrderLib.sol
@@ -13,7 +13,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 */
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 import "./MathLib.sol";
 

--- a/contracts/mocks/OrderLibMock.sol
+++ b/contracts/mocks/OrderLibMock.sol
@@ -14,7 +14,7 @@
     limitations under the License.
 */
 
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 import "../libraries/OrderLib.sol";
 

--- a/contracts/oraclize/MarketContractFactoryOraclize.sol
+++ b/contracts/oraclize/MarketContractFactoryOraclize.sol
@@ -14,7 +14,7 @@
     limitations under the License.
 */
 
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 import "./MarketContractOraclize.sol";
 import "../MarketContractRegistryInterface.sol";

--- a/contracts/oraclize/MarketContractOraclize.sol
+++ b/contracts/oraclize/MarketContractOraclize.sol
@@ -14,7 +14,7 @@
     limitations under the License.
 */
 
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 import "./oraclizeAPI.sol";
 import "../libraries/MathLib.sol";

--- a/contracts/oraclize/OraclizeQueryTest.sol
+++ b/contracts/oraclize/OraclizeQueryTest.sol
@@ -14,7 +14,7 @@
     limitations under the License.
 */
 
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 import "./oraclizeAPI.sol";
 import "../libraries/MathLib.sol";

--- a/contracts/oraclize/TestableMarketContractFactoryOraclize.sol
+++ b/contracts/oraclize/TestableMarketContractFactoryOraclize.sol
@@ -14,7 +14,7 @@
     limitations under the License.
 */
 
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 import "./TestableMarketContractOraclize.sol";
 import "../MarketContractRegistryInterface.sol";

--- a/contracts/oraclize/TestableMarketContractOraclize.sol
+++ b/contracts/oraclize/TestableMarketContractOraclize.sol
@@ -14,7 +14,7 @@
     limitations under the License.
 */
 
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 import "./MarketContractOraclize.sol";
 

--- a/contracts/oraclize/oraclizeAPI.sol
+++ b/contracts/oraclize/oraclizeAPI.sol
@@ -28,7 +28,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 contract OraclizeI {
     address public cbAddress;

--- a/contracts/tokens/CollateralToken.sol
+++ b/contracts/tokens/CollateralToken.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 import "openzeppelin-solidity/contracts/token/ERC20/StandardToken.sol";
 

--- a/contracts/tokens/MarketToken.sol
+++ b/contracts/tokens/MarketToken.sol
@@ -14,7 +14,7 @@
     limitations under the License.
 */
 
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 import "./UpgradableToken.sol";
 

--- a/contracts/tokens/UpgradableToken.sol
+++ b/contracts/tokens/UpgradableToken.sol
@@ -14,7 +14,7 @@
     limitations under the License.
 */
 
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 import "./UpgradeableTarget.sol";
 import "openzeppelin-solidity/contracts/token/ERC20/BurnableToken.sol";

--- a/contracts/tokens/UpgradeableTarget.sol
+++ b/contracts/tokens/UpgradeableTarget.sol
@@ -14,7 +14,7 @@
     limitations under the License.
 */
 
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 
 /// @title Upgradeable Target

--- a/contracts/tokens/UpgradeableTokenMock.sol
+++ b/contracts/tokens/UpgradeableTokenMock.sol
@@ -14,7 +14,7 @@
     limitations under the License.
 */
 
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 import "./UpgradeableTarget.sol";
 import "./UpgradableToken.sol";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "market-solidity",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "market-solidity",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "market-solidity",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "description": "Decentralized Derivatives Trading Protocol For The Ethereum Blockchain",
   "main": "truffle-config.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "market-solidity",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "description": "Decentralized Derivatives Trading Protocol For The Ethereum Blockchain",
   "main": "truffle-config.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "test"
   },
   "dependencies": {
-    "truffle": "4.1.8",
+    "truffle": "4.1.11",
     "openzeppelin-solidity": "1.9.0"
   },
   "devDependencies": {

--- a/test/TestCreatable.sol
+++ b/test/TestCreatable.sol
@@ -14,7 +14,7 @@
     limitations under the License.
 */
 
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 import "truffle/Assert.sol";
 import "../contracts/Creatable.sol";

--- a/test/libraries/TestMathLib.sol
+++ b/test/libraries/TestMathLib.sol
@@ -14,7 +14,7 @@
     limitations under the License.
 */
 
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 import "truffle/Assert.sol";
 import "../../contracts/libraries/MathLib.sol";

--- a/test/libraries/TestOrderLib.sol
+++ b/test/libraries/TestOrderLib.sol
@@ -14,7 +14,7 @@
     limitations under the License.
 */
 
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 import "truffle/Assert.sol";
 import "../../contracts/libraries/OrderLib.sol";


### PR DESCRIPTION
##### Description
Upgrade all contracts to use Solidity compiler 0.4.24 and Truffle 4.1.11.

##### Checklist

- [x] Linter status: 100% pass
- [x] Changes don't break existing behavior
- [x] Tests coverage hasn't decreased

##### Affected core subsystem(s)
contracts, tests

##### Testing
CI

##### Refers/Fixes
Refs: #91 