### PR TITLE
docker-compose.yml: Update bridge and wipe old eth-bridge configs bef…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     stdin_open: true
 
   eth-bridge:
-    image: marketproject/ethereum-bridge:0.5.6
+    image: cryptomental/ethereum-bridge:latest
     entrypoint: >
       /bin/bash -c "
         while ! curl ${TRUFFLE_DEVELOP_HOST}:${TRUFFLE_DEVELOP_PORT} &>/dev/null;
@@ -26,6 +26,8 @@ services:
         done;
         echo Ethereum node ready, connecting the Oraclize Bridge!;
         sleep 1;
+        echo Wiping old configs...;
+        rm -rf /ethereum-bridge/config/instance/*;
         node bridge -H ${TRUFFLE_DEVELOP_HOST}:${TRUFFLE_DEVELOP_PORT} -a 9 --dev;
       "
     restart: unless-stopped
@@ -50,7 +52,7 @@ services:
     stdin_open: true
 
   eth-bridge-coverage:
-    image: marketproject/ethereum-bridge:0.5.6
+    image: cryptomental/ethereum-bridge:latest
     entrypoint: >
       /bin/bash -c "
         while ! curl ${TRUFFLE_COVERAGE_HOST}:${TRUFFLE_COVERAGE_PORT} &>/dev/null;
@@ -60,6 +62,8 @@ services:
         done;
         echo Ethereum node ready, connecting the Oraclize Bridge!;
         sleep 1;
+        echo Wiping old configs...;
+        rm -rf /ethereum-bridge/config/instance/*;
         node bridge -H ${TRUFFLE_COVERAGE_HOST}:${TRUFFLE_COVERAGE_PORT} -a 9 --dev;
       "
 


### PR DESCRIPTION
##### Description
The latest eth-bridge contains 180 sec timeout change, and was upgraded to 0.6.0.
Configs are wiped to avoid a situation when the bridge restarts and keeps the old one.
In that situation the script would time out on Travis.

I can also later rebase marketprotocol/eth-bridge repo if needed.

##### Checklist

- [x] Linter status: 100% pass
- [x] Changes don't break existing behavior
- [x] Tests coverage hasn't decreased

##### Affected core subsystem(s)
CI

##### Testing
CI

##### Refers/Fixes
Refs: MARKET.js #33
