### PR TITLE
add / cleanup tests

### DIFF
--- a/contracts/MarketContractRegistry.sol
+++ b/contracts/MarketContractRegistry.sol
@@ -24,9 +24,9 @@ import "./MarketContractRegistryInterface.sol";
 /// @author Phil Elsasser <phil@marketprotocol.io>
 contract MarketContractRegistry is Ownable, MarketContractRegistryInterface {
 
-    mapping(address => bool) isWhiteListed;
-    address[] addressWhiteList;                             // record of currently deployed addresses;
-    mapping(address => bool) factoryAddressWhiteList;       // record of authorized factories
+    mapping(address => bool) public isWhiteListed;
+    address[] public addressWhiteList;                             // record of currently deployed addresses;
+    mapping(address => bool) public factoryAddressWhiteList;       // record of authorized factories
 
     // events
     event AddressAddedToWhitelist(address indexed contractAddress);

--- a/contracts/chainlink/OracleHubChainLink.sol
+++ b/contracts/chainlink/OracleHubChainLink.sol
@@ -117,7 +117,6 @@ contract OracleHubChainLink is OracleHub, Chainlinked {
     function callback(bytes32 requestId, uint256 price) external checkChainlinkFulfillment(requestId) {
         // NOTE: event is emitted by chainlink upon call above to checkChainlinkFulfillment
         ChainLinkQuery memory chainLinkQuery = requestIDToChainLinkQuery[requestId];
-        require(chainLinkQuery.marketContractAddress != address(0), "market contract address can not be null!");
         MarketContractChainLink(chainLinkQuery.marketContractAddress).oracleCallBack(price);
     }
 

--- a/test/MarketContractRegistry.js
+++ b/test/MarketContractRegistry.js
@@ -3,6 +3,7 @@ const MarketCollateralPool = artifacts.require('MarketCollateralPool');
 const MarketToken = artifacts.require('MarketToken');
 const MarketContractRegistry = artifacts.require('MarketContractRegistry');
 const CollateralToken = artifacts.require('CollateralToken');
+const MarketContractFactory = artifacts.require('./chainlink/MarketContractFactoryChainLink.sol');
 
 contract('MarketContractRegistry', function(accounts) {
   let collateralPool;
@@ -190,6 +191,48 @@ contract('MarketContractRegistry', function(accounts) {
     assert.ok(
       error instanceof Error,
       "removing non white listed contract to whitelist by non owner didn't fail!"
+    );
+  });
+
+  it('Only owner is able to remove factory address', async function() {
+    const ownerAddress = await marketContractRegistry.owner.call();
+    assert.equal(accounts[0], ownerAddress, "owner isn't our first account");
+
+    const factoryAddress = MarketContractFactory.address;
+    const fakeFactoryAddress = accounts[3];
+
+    let error = null;
+    try {
+      await marketContractRegistry.removeFactoryAddress(
+        fakeFactoryAddress,
+        { from: accounts[0] }
+      );
+    } catch (err) {
+      error = err;
+    }
+    assert.ok(
+      error instanceof Error,
+      "removing non factory address should fail!"
+    );
+
+    await marketContractRegistry.removeFactoryAddress(
+      factoryAddress,
+      { from: accounts[0] }
+    );
+
+    assert.isTrue(
+      !(await marketContractRegistry.factoryAddressWhiteList(factoryAddress)),
+      "Removed factory address not removed from mapping"
+    );
+
+    await marketContractRegistry.addFactoryAddress(
+      factoryAddress,
+      { from: accounts[0] }
+    );
+
+    assert.isTrue(
+      await marketContractRegistry.factoryAddressWhiteList(factoryAddress),
+      "Factory address added back"
     );
   });
 });

--- a/test/TestLinkable.sol
+++ b/test/TestLinkable.sol
@@ -1,0 +1,32 @@
+/*
+    Copyright 2017-2018 Phillip A. Elsasser
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+pragma solidity ^0.4.24;
+
+import "truffle/Assert.sol";
+import "../contracts/Linkable.sol";
+
+contract TestLinkable {
+
+    function testLinkableCreation() public {
+        Linkable linkable = new Linkable(msg.sender);
+        Assert.equal(
+            msg.sender,
+            linkable.linkedAddress(),
+            "Linked address is as expected in constructor"
+        );
+    }
+}

--- a/test/chainlink/OracleHubChainLink.js
+++ b/test/chainlink/OracleHubChainLink.js
@@ -81,15 +81,22 @@ contract('OracleHubChainLink', function(accounts) {
   });
 
   it('requestQuery can be called by factory address', async function() {
-    const originalContractFactoryAddress = await oracleHubChainLink.marketContractFactoryAddress();
     let error = null;
     try {
-      await oracleHubChainLink.setFactoryAddress(accounts[1], {from: accounts[1]});
+      await oracleHubChainLink.requestQuery(
+        marketContract.address,
+        'https://api.kraken.com/0/public/Ticker?pair=ETHUSD',
+        'result.XETHZUSD.c.0',
+        'fakeSleepJobId',
+        'fakeOnDemandJobId',
+        {from: accounts[1]}
+      );
     } catch (err) {
       error = err;
     }
-    assert.ok(error instanceof Error, 'should not be able to set factory from non-owner account');
+    assert.ok(error instanceof Error, 'should not be able to call request query from non factory address');
 
+    const originalContractFactoryAddress = await oracleHubChainLink.marketContractFactoryAddress();
     // set factory address to an account we can call from
     oracleHubChainLink.setFactoryAddress(accounts[1], {from: accounts[0]});
     oracleHubChainLink.requestQuery(

--- a/test/libraries/OrderLib.js
+++ b/test/libraries/OrderLib.js
@@ -1,5 +1,5 @@
 const OrderLib = artifacts.require('OrderLibMock');
-const utility = require('./utility.js');
+const utility = require('../utility.js');
 const MarketContractOraclize = artifacts.require('TestableMarketContractOraclize');
 const MarketCollateralPool = artifacts.require('MarketCollateralPool');
 const MarketContractRegistry = artifacts.require('MarketContractRegistry');


### PR DESCRIPTION
##### Description
Adds a few tests for missed lines in coverage reports. 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Linter status: 100% pass
- [x] Changes don't break existing behavior
- [x] Tests coverage hasn't decreased

##### Affected core subsystem(s)
tests

##### Refers/Fixes
fixes #150