### PR TITLE
Support USDT

### DIFF
--- a/contracts/MarketCollateralPool.sol
+++ b/contracts/MarketCollateralPool.sol
@@ -202,6 +202,7 @@ contract MarketCollateralPool is Ownable {
             marketContract.PRICE_FLOOR(),
             marketContract.PRICE_CAP(),
             marketContract.QTY_MULTIPLIER(),
+            marketContract.QTY_DENOMINATOR(),
             longQtyToRedeem,
             shortQtyToRedeem,
             marketContract.settlementPrice()

--- a/contracts/MarketCollateralPool.sol
+++ b/contracts/MarketCollateralPool.sol
@@ -84,7 +84,7 @@ contract MarketCollateralPool is Ownable {
         require(!marketContract.isSettled(), "Contract is already settled");
 
         address collateralTokenAddress = marketContract.COLLATERAL_TOKEN_ADDRESS();
-        uint neededCollateral = MathLib.multiply(qtyToMint, marketContract.COLLATERAL_PER_UNIT());
+        uint neededCollateral = MathLib.divideFractional(qtyToMint, marketContract.COLLATERAL_PER_UNIT(), marketContract.QTY_DENOMINATOR());
         // the user has selected to pay fees in MKT and those fees are non zero (allowed) OR
         // the user has selected not to pay fees in MKT, BUT the collateral token fees are disabled (0) AND the
         // MKT fees are enabled (non zero).  (If both are zero, no fee exists)
@@ -106,7 +106,7 @@ contract MarketCollateralPool is Ownable {
             // ERC20.approve in order for this call to succeed.
             ERC20(mktToken).safeTransferFrom(msg.sender, address(this), feeAmount);
         } else { // fee are either zero, or being paid in the collateral token
-            feeAmount = MathLib.multiply(qtyToMint, marketContract.COLLATERAL_TOKEN_FEE_PER_UNIT());
+            feeAmount = MathLib.divideFractional(qtyToMint, marketContract.COLLATERAL_TOKEN_FEE_PER_UNIT(), marketContract.QTY_DENOMINATOR());
             totalCollateralTokenTransferAmount = neededCollateral.add(feeAmount);
             feeToken = collateralTokenAddress;
             // we will transfer collateral and fees all at once below.

--- a/contracts/MarketContract.sol
+++ b/contracts/MarketContract.sol
@@ -37,6 +37,7 @@ contract MarketContract is Ownable {
     uint public PRICE_FLOOR;
     uint public PRICE_DECIMAL_PLACES;   // how to convert the pricing from decimal format (if valid) to integer
     uint public QTY_MULTIPLIER;         // multiplier corresponding to the value of 1 increment in price to token base units
+    uint public QTY_DENOMINATOR;        // denominator corresponding to the value of 1 increment in price to token base units
     uint public COLLATERAL_PER_UNIT;    // required collateral amount for the full range of outcome tokens
     uint public COLLATERAL_TOKEN_FEE_PER_UNIT;
     uint public MKT_TOKEN_FEE_PER_UNIT;
@@ -72,10 +73,11 @@ contract MarketContract is Ownable {
     ///     feeInBasisPoints    fee amount in basis points (Collateral token denominated) for minting.
     ///     mktFeeInBasisPoints fee amount in basis points (MKT denominated) for minting.
     ///     expirationTimeStamp seconds from epoch that this contract expires and enters settlement
+    ///     qtyDenominator      division traded qty by this value from base units of collateral token.
     constructor(
         bytes32[3] memory contractNames,
         address[3] memory baseAddresses,
-        uint[7] memory contractSpecs
+        uint[8] memory contractSpecs
     ) public
     {
         PRICE_FLOOR = contractSpecs[0];
@@ -84,9 +86,11 @@ contract MarketContract is Ownable {
 
         PRICE_DECIMAL_PLACES = contractSpecs[2];
         QTY_MULTIPLIER = contractSpecs[3];
+        QTY_DENOMINATOR = contractSpecs[7];
         EXPIRATION = contractSpecs[6];
         require(EXPIRATION > now, "EXPIRATION must be in the future");
         require(QTY_MULTIPLIER != 0,"QTY_MULTIPLIER cannot be 0");
+        require(QTY_DENOMINATOR != 0,"QTY_DENOMINATOR cannot be 0");
 
         COLLATERAL_TOKEN_ADDRESS = baseAddresses[1];
         COLLATERAL_POOL_ADDRESS = baseAddresses[2];

--- a/contracts/libraries/MathLib.sol
+++ b/contracts/libraries/MathLib.sol
@@ -64,6 +64,7 @@ library MathLib {
         uint priceFloor,
         uint priceCap,
         uint qtyMultiplier,
+        uint qtyDenominator,
         uint longQty,
         uint shortQty,
         uint price
@@ -88,6 +89,7 @@ library MathLib {
             }
             neededCollateral = add(neededCollateral, multiply(multiply(maxLoss, shortQty),  qtyMultiplier));
         }
+        neededCollateral = neededCollateral / qtyDenominator;
         return neededCollateral;
     }
 

--- a/contracts/mpx/MarketContractFactoryMPX.sol
+++ b/contracts/mpx/MarketContractFactoryMPX.sol
@@ -65,12 +65,13 @@ contract MarketContractFactoryMPX is Ownable {
     ///     feeInBasisPoints    fee amount in basis points (Collateral token denominated) for minting.
     ///     mktFeeInBasisPoints fee amount in basis points (MKT denominated) for minting.
     ///     expirationTimeStamp     seconds from epoch that this contract expires and enters settlement
+    ///     qtyDenominator          division traded qty by this value from base units of collateral token.
     /// @param oracleURL url of data
     /// @param oracleStatistic statistic type (lastPrice, vwap, etc)
     function deployMarketContractMPX(
         bytes32[3] calldata contractNames,
         address collateralTokenAddress,
-        uint[7] calldata contractSpecs,
+        uint[8] calldata contractSpecs,
         string calldata oracleURL,
         string calldata oracleStatistic
     ) external onlyOwner

--- a/contracts/mpx/MarketContractMPX.sol
+++ b/contracts/mpx/MarketContractMPX.sol
@@ -45,13 +45,14 @@ contract MarketContractMPX is MarketContract {
     ///     feeInBasisPoints    fee amount in basis points (Collateral token denominated) for minting.
     ///     mktFeeInBasisPoints fee amount in basis points (MKT denominated) for minting.
     ///     expirationTimeStamp     seconds from epoch that this contract expires and enters settlement
+    ///     qtyDenominator          division traded qty by this value from base units of collateral token.
     /// @param oracleURL url of data
     /// @param oracleStatistic statistic type (lastPrice, vwap, etc)
     constructor(
         bytes32[3] memory contractNames,
         address[3] memory baseAddresses,
         address oracleHubAddress,
-        uint[7] memory contractSpecs,
+        uint[8] memory contractSpecs,
         string memory oracleURL,
         string memory oracleStatistic
     ) MarketContract(

--- a/migrations/2_market_contracts.js
+++ b/migrations/2_market_contracts.js
@@ -67,7 +67,8 @@ module.exports = async function(deployer, network, accounts) {
                                             100000000,
                                             25,
                                             12,
-                                            marketContractExpiration
+                                            marketContractExpiration,
+                                            1
                                           ],
                                           'api.coincap.io/v2/rates/bitcoin',
                                           'rateUsd',
@@ -88,7 +89,8 @@ module.exports = async function(deployer, network, accounts) {
                                               25,
                                               12,
                                               100000000,
-                                              marketContractExpiration
+                                              marketContractExpiration,
+                                              1
                                             ],
                                             'api.coincap.io/v2/rates/bitcoin',
                                             'rateUsd',

--- a/test/MarketCollateralPool.js
+++ b/test/MarketCollateralPool.js
@@ -16,6 +16,7 @@ contract('MarketCollateralPool', function(accounts) {
   let marketContractRegistry;
   let mktToken;
   let qtyMultiplier;
+  let qtyDenominator;
   let priceFloor;
   let priceCap;
   let longPositionToken;
@@ -48,7 +49,7 @@ contract('MarketCollateralPool', function(accounts) {
       collateralPool,
       accounts[0],
       accounts[0],
-      [0, 150, 2, 1, 0, 0, utility.expirationInDays(1)]
+      [0, 150, 2, 1, 0, 0, utility.expirationInDays(1), 1]
     );
 
     feeMarketContract = await utility.createMarketContract(
@@ -56,7 +57,7 @@ contract('MarketCollateralPool', function(accounts) {
       collateralPool,
       accounts[0],
       accounts[0],
-      [0, 150, 2, 2, collateralFee, mktFee, utility.expirationInDays(1)]
+      [0, 150, 2, 2, collateralFee, mktFee, utility.expirationInDays(1), 1]
     );
 
     await marketContractRegistry.addAddressToWhiteList(marketContract.address, {
@@ -67,6 +68,7 @@ contract('MarketCollateralPool', function(accounts) {
     });
 
     qtyMultiplier = await marketContract.QTY_MULTIPLIER.call();
+    qtyDenominator = await marketContract.QTY_DENOMINATOR.call();
     priceFloor = await marketContract.PRICE_FLOOR.call();
     priceCap = await marketContract.PRICE_CAP.call();
     longPositionToken = await PositionToken.at(await marketContract.LONG_POSITION_TOKEN());
@@ -363,7 +365,7 @@ contract('MarketCollateralPool', function(accounts) {
           collateralPool,
           accounts[0],
           accounts[0],
-          [0, 150, 2, 1, 0, mktFee, utility.expirationInDays(1)]
+          [0, 150, 2, 1, 0, mktFee, utility.expirationInDays(1), 1]
         );
         mktFeePerUnit = await mktFeeMarketContract.MKT_TOKEN_FEE_PER_UNIT.call();
 
@@ -445,7 +447,7 @@ contract('MarketCollateralPool', function(accounts) {
           collateralPool,
           accounts[0],
           accounts[0],
-          [0, 150, 2, 1, collateralFee, 0, utility.expirationInDays(1)]
+          [0, 150, 2, 1, collateralFee, 0, utility.expirationInDays(1), 1]
         );
         collateralFeePerUnit = await collateralFeeMarketContract.COLLATERAL_TOKEN_FEE_PER_UNIT.call();
 
@@ -476,9 +478,9 @@ contract('MarketCollateralPool', function(accounts) {
 
         it('should still charge correct collateralFees', async function() {
           const expectedCollateralFee = collateralFeePerUnit.mul(qtyToMint);
-          const expectedCollateralTransfer = (await collateralFeeMarketContract.COLLATERAL_PER_UNIT()).mul(
-            qtyToMint
-          );
+          const expectedCollateralTransfer = (
+            await collateralFeeMarketContract.COLLATERAL_PER_UNIT()
+          ).mul(qtyToMint);
 
           const finalCollateralBalance = await collateralToken.balanceOf.call(accounts[0]);
           const actualCollateralFee = initialCollateralBalance
@@ -520,9 +522,9 @@ contract('MarketCollateralPool', function(accounts) {
 
         it('should still charge correct collateralFees', async function() {
           const expectedCollateralFee = collateralFeePerUnit.mul(qtyToMint);
-          const expectedCollateralTransfer = (await collateralFeeMarketContract.COLLATERAL_PER_UNIT()).mul(
-            qtyToMint
-          );
+          const expectedCollateralTransfer = (
+            await collateralFeeMarketContract.COLLATERAL_PER_UNIT()
+          ).mul(qtyToMint);
 
           const finalCollateralBalance = await collateralToken.balanceOf.call(accounts[0]);
           const actualCollateralFee = initialCollateralBalance
@@ -844,6 +846,7 @@ contract('MarketCollateralPool', function(accounts) {
         priceFloor,
         priceCap,
         qtyMultiplier,
+        qtyDenominator,
         shortTokenQtyToRedeem.mul(new BN('-1')),
         settlementPrice
       );
@@ -909,6 +912,7 @@ contract('MarketCollateralPool', function(accounts) {
         priceFloor,
         priceCap,
         qtyMultiplier,
+        qtyDenominator,
         longTokenQtyToRedeem,
         settlementPrice
       );
@@ -972,6 +976,7 @@ contract('MarketCollateralPool', function(accounts) {
         priceFloor,
         priceCap,
         qtyMultiplier,
+        qtyDenominator,
         qtyToRedeem.mul(new BN('-1')),
         settlementPrice
       );

--- a/test/MarketCollateralPool.js
+++ b/test/MarketCollateralPool.js
@@ -1222,14 +1222,13 @@ contract('MarketCollateralPool', function(accounts) {
       });
 
       // 2. balance after should be equal to expected balance
+      const expectedCollateralFee = collateralFeePerUnit.mul(qtyToMint).div(qtyDenominator);
       const amountToBeLocked = qtyToMint
-        .mul(
-          utility
-            .calculateTotalCollateral(priceFloor, priceCap, qtyMultiplier)
-            .add(collateralFeePerUnit)
-        )
+        .mul(utility.calculateTotalCollateral(priceFloor, priceCap, qtyMultiplier))
         .div(qtyDenominator);
-      const expectedBalanceAfterMint = initialCollateralBalance.sub(amountToBeLocked);
+      const expectedBalanceAfterMint = initialCollateralBalance
+        .sub(amountToBeLocked)
+        .sub(expectedCollateralFee);
       const actualBalanceAfterMint = await collateralToken.balanceOf.call(accounts[0]);
 
       assert.isTrue(

--- a/test/MarketContract.js
+++ b/test/MarketContract.js
@@ -21,6 +21,7 @@ contract('MarketContract', function(accounts) {
       const priceCap = new BN('100');
       const priceDecimalPlaces = new BN('2');
       const qtyMultiplier = new BN('10');
+      const qtyDenominator = new BN('1');
       const expiration = Math.floor(new Date().getTime() / 1000 + 60 * 50);
       const fees = new BN('0');
 
@@ -29,7 +30,16 @@ contract('MarketContract', function(accounts) {
         collateralPool,
         accounts[0],
         null,
-        [priceFloor, priceCap, priceDecimalPlaces, qtyMultiplier, fees, fees, expiration]
+        [
+          priceFloor,
+          priceCap,
+          priceDecimalPlaces,
+          qtyMultiplier,
+          fees,
+          fees,
+          expiration,
+          qtyDenominator
+        ]
       );
 
       assert.isTrue(
@@ -80,6 +90,8 @@ contract('MarketContract', function(accounts) {
       const lowerPriceCap = 100;
       const priceDecimalPlaces = 2;
       const qtyMultiplier = 10;
+      const qtyDenominator = 1;
+      const fees = 0;
       const expiration = Math.floor(new Date().getTime() / 1000 + 60 * 50);
 
       await utility.shouldFail(async function() {
@@ -88,7 +100,10 @@ contract('MarketContract', function(accounts) {
           lowerPriceCap,
           priceDecimalPlaces,
           qtyMultiplier,
-          expiration
+          expiration,
+          fees,
+          fees,
+          qtyDenominator
         ]);
       });
     });
@@ -98,6 +113,8 @@ contract('MarketContract', function(accounts) {
       const priceCap = 100;
       const priceDecimalPlaces = 2;
       const qtyMultiplier = 10;
+      const qtyDenominator = 1;
+      const fees = 0;
       const pastExpiration = Math.floor(new Date().getTime() / 1000 - 60 * 50); // 50 mins in the past
 
       await utility.shouldFail(async function() {
@@ -106,7 +123,10 @@ contract('MarketContract', function(accounts) {
           priceCap,
           priceDecimalPlaces,
           qtyMultiplier,
-          pastExpiration
+          fees,
+          fees,
+          pastExpiration,
+          qtyDenominator
         ]);
       });
     });

--- a/test/libraries/TestMathLib.sol
+++ b/test/libraries/TestMathLib.sol
@@ -54,12 +54,14 @@ contract TestMathLib {
         uint priceFloor = 250;
         uint priceCap = 350;
         uint qtyMultiplier = 100;
+        uint qtyDenominator = 1;
         uint price = 275;
         uint longQty = 2;
         uint neededCollateralForLongPos = MathLib.calculateCollateralToReturn(
             priceFloor,
             priceCap,
             qtyMultiplier,
+            qtyDenominator,
             longQty,
             0,
             price
@@ -70,11 +72,11 @@ contract TestMathLib {
         Assert.equal(neededCollateralForLongPos, 5000, "max loss of 25 and qty of 2 with 100 multiplier should be 5000 units");
 
         // neededCollateral for a long position and price equal to priceFloor returns zero
-        Assert.equal(MathLib.calculateCollateralToReturn(priceFloor, priceCap, qtyMultiplier, longQty, 0, priceFloor),
+        Assert.equal(MathLib.calculateCollateralToReturn(priceFloor, priceCap, qtyMultiplier, qtyDenominator, longQty, 0, priceFloor),
                      0, "collateral for a long position and price equal to priceFloor should be 0");
 
         // neededCollateral for a long position and price less than priceFloor returns zero
-        Assert.equal(MathLib.calculateCollateralToReturn(priceFloor, priceCap, qtyMultiplier, longQty, 0, priceFloor-1),
+        Assert.equal(MathLib.calculateCollateralToReturn(priceFloor, priceCap, qtyMultiplier, qtyDenominator, longQty, 0, priceFloor-1),
                      0, "collateral for a long position and price less than priceFloor should be 0");
     }
 
@@ -82,6 +84,7 @@ contract TestMathLib {
         uint priceFloor = 250;
         uint priceCap = 350;
         uint qtyMultiplier = 100;
+        uint qtyDenominator = 1;
         uint price = 275;
         uint shortQty = 5;
 
@@ -89,6 +92,7 @@ contract TestMathLib {
             priceFloor,
             priceCap,
             qtyMultiplier,
+            qtyDenominator,
             0,
             shortQty,
             price
@@ -98,11 +102,11 @@ contract TestMathLib {
         Assert.equal(neededCollateralForShortPos, 37500, "max loss of 75 and qty of 5 with 100 multiplier should be 37500 units");
 
         // neededCollateral for a short position and price equal to priceCap returns zero
-        Assert.equal(MathLib.calculateCollateralToReturn(priceFloor, priceCap, qtyMultiplier, 0, shortQty, priceCap),
+        Assert.equal(MathLib.calculateCollateralToReturn(priceFloor, priceCap, qtyMultiplier, qtyDenominator, 0, shortQty, priceCap),
                      0, "collateral for a short position and price equal to priceCap should be 0");
 
         // neededCollateral for a short position and price greater than priceCap returns zero
-        Assert.equal(MathLib.calculateCollateralToReturn(priceFloor, priceCap, qtyMultiplier, 0, shortQty, priceCap+1),
+        Assert.equal(MathLib.calculateCollateralToReturn(priceFloor, priceCap, qtyMultiplier, qtyDenominator, 0, shortQty, priceCap+1),
                      0, "collateral for a short position and price greater than priceCap should be 0");
     }
 
@@ -110,6 +114,7 @@ contract TestMathLib {
         uint priceFloor = 250;
         uint priceCap = 350;
         uint qtyMultiplier = 100;
+        uint qtyDenominator = 1;
         uint price = 275;
         uint shortQty = 5;
         uint longQty = 1;
@@ -118,6 +123,7 @@ contract TestMathLib {
             priceFloor,
             priceCap,
             qtyMultiplier,
+            qtyDenominator,
             1,
             shortQty,
             price

--- a/test/mpx/MarketContractFactoryMPX.js
+++ b/test/mpx/MarketContractFactoryMPX.js
@@ -17,6 +17,7 @@ contract('MarketContractFactoryMPX', function(accounts) {
   const priceFloor = 20155;
   const priceDecimalPlaces = 2;
   const qtyMultiplier = 10;
+  const qtyDenominator = 1;
   const feesInCollateralToken = 20;
   const feesInMKTToken = 10;
 
@@ -39,7 +40,8 @@ contract('MarketContractFactoryMPX', function(accounts) {
         qtyMultiplier,
         feesInCollateralToken,
         feesInMKTToken,
-        expiration
+        expiration,
+        qtyDenominator
       ],
       oracleURL,
       oracleStatistic
@@ -57,6 +59,7 @@ contract('MarketContractFactoryMPX', function(accounts) {
     assert.equal(await marketContract.ORACLE_STATISTIC(), oracleStatistic);
     assert.equal((await marketContract.EXPIRATION()).toNumber(), expiration);
     assert.equal((await marketContract.QTY_MULTIPLIER()).toNumber(), qtyMultiplier);
+    assert.equal((await marketContract.QTY_DENOMINATOR()).toNumber(), qtyDenominator);
     assert.equal((await marketContract.PRICE_DECIMAL_PLACES()).toNumber(), priceDecimalPlaces);
     assert.equal((await marketContract.PRICE_FLOOR()).toNumber(), priceFloor);
     assert.equal((await marketContract.PRICE_CAP()).toNumber(), priceCap);
@@ -78,7 +81,8 @@ contract('MarketContractFactoryMPX', function(accounts) {
         qtyMultiplier,
         feesInCollateralToken,
         feesInMKTToken,
-        expiration
+        expiration,
+        qtyDenominator
       ],
       oracleURL,
       oracleStatistic

--- a/test/mpx/MarketContractMPX.js
+++ b/test/mpx/MarketContractMPX.js
@@ -19,7 +19,7 @@ contract('MarketContractMPX', function(accounts) {
       contractNames,
       [accounts[0], CollateralToken.address, MarketCollateralPool.address],
       accounts[8], // substitute our address for the oracleHubAddress so we can callback from queries.
-      [0, 150, 2, 2, 0, 0, expiration],
+      [0, 150, 2, 2, 0, 0, expiration, 1],
       oracleURL,
       oracleStatistic
     );
@@ -90,7 +90,7 @@ contract('MarketContractMPX', function(accounts) {
       contractNames,
       [accounts[0], CollateralToken.address, MarketCollateralPool.address],
       accounts[8], // substitute our address for the oracleHubAddress so we can callback from queries.
-      [25, 150, 2, 2, 0, 0, expiration],
+      [25, 150, 2, 2, 0, 0, expiration, 1],
       oracleURL,
       oracleStatistic
     );

--- a/test/tokens/PositionToken.js
+++ b/test/tokens/PositionToken.js
@@ -37,6 +37,7 @@ contract('PositionToken', function(accounts) {
     });
 
     qtyMultiplier = await marketContract.QTY_MULTIPLIER.call();
+    qtyDenominator = await marketContract.QTY_DENOMINATOR.call();
     priceFloor = await marketContract.PRICE_FLOOR.call();
     priceCap = await marketContract.PRICE_CAP.call();
     longPositionToken = await PositionToken.at(await marketContract.LONG_POSITION_TOKEN());

--- a/test/utility.js
+++ b/test/utility.js
@@ -69,7 +69,7 @@ module.exports = {
    * @param price
    * @return {number}
    */
-  calculateCollateralToReturn(priceFloor, priceCap, qtyMultiplier, qty, price) {
+  calculateCollateralToReturn(priceFloor, priceCap, qtyMultiplier, qtyDenominator, qty, price) {
     const zero = 0;
     let maxLoss;
     if (qty > zero) {
@@ -85,7 +85,10 @@ module.exports = {
         maxLoss = priceCap.sub(price);
       }
     }
-    return maxLoss.mul(qty.abs()).mul(qtyMultiplier);
+    return maxLoss
+      .mul(qty.abs())
+      .mul(qtyMultiplier)
+      .div(qtyDenominator);
   },
 
   /**
@@ -126,7 +129,7 @@ module.exports = {
     }
 
     if (!contractSpecs) {
-      contractSpecs = [0, 150, 2, 2, 100, 50, expiration];
+      contractSpecs = [0, 150, 2, 2, 100, 50, expiration, 1];
     }
     const contractNames = [
       web3.utils.asciiToHex('BTC', 32),

--- a/test/utility.js
+++ b/test/utility.js
@@ -70,16 +70,16 @@ module.exports = {
    * @return {number}
    */
   calculateCollateralToReturn(priceFloor, priceCap, qtyMultiplier, qtyDenominator, qty, price) {
-    const zero = 0;
+    const zero = new BN('0');
     let maxLoss;
-    if (qty > zero) {
-      if (price <= priceFloor) {
+    if (qty.gt(zero)) {
+      if (price.lte(priceFloor)) {
         maxLoss = zero;
       } else {
         maxLoss = price.sub(priceFloor);
       }
     } else {
-      if (price >= priceCap) {
+      if (price.gte(priceCap)) {
         maxLoss = zero;
       } else {
         maxLoss = priceCap.sub(price);


### PR DESCRIPTION
<!--
  Thank you for your pull request. Please provide a description
  above and review the requirements below.

  Contributors guide:
  https://github.com/MARKETProtocol/meta/blob/master/CONTRIBUTING.md
-->

##### Description
<!-- A description on what this PR aims to solve. -->

It is impossible to mint a position token when ctk is USDT (https://etherscan.io/address/0xdAC17F958D2ee523a2206206994597C13D831ec7) because USDT.decimals = 6

In this pull request, we add a qtyDenominator so that:

```
       (Cap - Floor) * qtyMultiplier * qty
CTK = -------------------------------------
                qtyDenominator
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Linter status: 100% pass
- [x] Changes don't break existing behavior: If qtyDenominator = 1 in new MarketContract, all behaviors are the same
- [x] Tests coverage hasn't decreased

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like Docs, UI, UX, Tests etc). -->

UI changes: 
* Formular of required CTK changes
* Revenue calculator changes

##### Testing
<!-- Why should the PR reviewer trust that this change doesn't break
  anything? How have you tested this change?
-->

We added some unit tests.

##### Refers/Fixes
<!--
  Link to an issue if applicable. For example:
  If your PR fixes an issue -- Fixes: #102
  If your PR refers an issue -- Refs: #101
-->
